### PR TITLE
Feat - `acknowledge` modifier for `SharedStateParameter`

### DIFF
--- a/src/common/ParameterBag.js
+++ b/src/common/ParameterBag.js
@@ -12,6 +12,7 @@ export const sharedOptions = {
   metas: {},
   filterChange: true,
   immediate: false,
+  acknowledge: true,
 };
 
 export const types = {

--- a/src/common/shared-state-types.js
+++ b/src/common/shared-state-types.js
@@ -52,25 +52,33 @@
  * @property {boolean} [event=false] - Define if the parameter is a volatile, i.e.
  *   its value only exists on an update and is set back to `null` after propagation.
  *   When `true`, `nullable` is automatically set to `true` and `default` to `null`.
+ * @property {boolean} [required=false] - When set to true, the parameter must be
+ *   provided at the creation of the shared state.
  * @property {boolean} [filterChange=true] - When set to `false`, an update will
  *   trigger the propagation of a parameter even when its value didn't change.
- *   This option provides a sort of middle ground between the default behavior
+ *   This modifier provides a sort of middle ground between the default behavior
  *   (e.g. where only changed values are propagated) and the behavior of the `event`
  *   option (which has no state per se). Hence, setting this options to `false` if
  *   `event=true` makes no sens.
  * @property {boolean} [immediate=false] - When set to `true`, an update will
  *   trigger the update listeners immediately on the node that generated the update,
- *   before propagating the change on the network.
- *   This option is useful in cases the network would introduce a noticeable
- *   latency on the client.
+ *   before propagating the change on the network. This modifier is useful in cases
+ *   the network would introduce a noticeable latency on the client.
  *   If for some reason the value is overridden server-side (e.g. in an `updateHook`)
  *   the listeners will be called again when the "real" value is received.
- * @property {boolean} [required=false] - When set to true, the parameter must be
- *   provided in the initialization values when the state is created.
+ *   Setting this modifier to `true` will trigger the `onUpdate` callback synchronously
+ *   according to the `set` call.
  * @property {boolean} [local=false] - When set to true, the parameter is never
  *   propagated on the network (hence it is no longer a shared parameter :). This
  *   is useful to declare some common parameter (e.g. some interface state) that
  *   don't need to be shared but to stay in the shared state API paradigm.
+ *   Setting this modifier to `true` will trigger the `onUpdate` callback synchronously
+ *   according to the `set` call.
+ * @property {boolean} [acknowledge=true] - When set to false, the acknowledgement
+ *   is never sent back to the shared state that initiated an update. This can be
+ *   useful to e.g. stream values to the network, but can lead to invalid state.
+ *   Setting this modifier to `true` will trigger the `onUpdate` callback synchronously
+ *   according to the `set` call.
  * @property {number} [min=-Number.MIN_VALUE] - Minimum value of the parameter. Only applies
  *   for `integer` and `float` types.
  * @property {number} [max=Number.MAX_VALUE] - Maximum value of the parameter. Only applies

--- a/tests/states/ParameterBag.spec.js
+++ b/tests/states/ParameterBag.spec.js
@@ -258,7 +258,8 @@ describe('# [private] ParameterBag', () => {
           immediate: false,
           type: 'boolean',
           default: false,
-          initValue: true
+          initValue: true,
+          acknowledge: true,
         },
         int: {
           nullable: false,
@@ -271,7 +272,8 @@ describe('# [private] ParameterBag', () => {
           max: 2,
           type: 'integer',
           default: 0,
-          initValue: -2
+          initValue: -2,
+          acknowledge: true,
         },
         nullable: {
           nullable: true,
@@ -282,7 +284,8 @@ describe('# [private] ParameterBag', () => {
           immediate: false,
           type: 'any',
           default: {},
-          initValue: {}
+          initValue: {},
+          acknowledge: true,
         },
         event: {
           nullable: true,
@@ -295,7 +298,8 @@ describe('# [private] ParameterBag', () => {
           max: Infinity,
           type: 'float',
           default: null,
-          initValue: null
+          initValue: null,
+          acknowledge: true,
         },
         required: {
           nullable: false,
@@ -306,7 +310,8 @@ describe('# [private] ParameterBag', () => {
           immediate: false,
           type: 'string',
           default: 'coucou',
-          initValue: 'coucou'
+          initValue: 'coucou',
+          acknowledge: true,
         }
       };
 

--- a/tests/utils/class-description.js
+++ b/tests/utils/class-description.js
@@ -56,6 +56,7 @@ export const expectedFullClassDescription = {
     "nullable": false,
     "required": false,
     "type": "boolean",
+    "acknowledge": true,
   },
   "int": {
     "default": 0,
@@ -69,6 +70,7 @@ export const expectedFullClassDescription = {
     "required": false,
     "step": 1,
     "type": "integer",
+    "acknowledge": true,
   },
   "required": {
     "default": null,
@@ -79,6 +81,7 @@ export const expectedFullClassDescription = {
     "nullable": false,
     "required": true,
     "type": "boolean",
+    "acknowledge": true,
   },
 };
 
@@ -94,6 +97,7 @@ export const expectedInstanceFullClassDescription = {
     "nullable": false,
     "required": false,
     "type": "boolean",
+    "acknowledge": true,
   },
   "int": {
     "default": 0,
@@ -108,6 +112,7 @@ export const expectedInstanceFullClassDescription = {
     "required": false,
     "step": 1,
     "type": "integer",
+    "acknowledge": true,
   },
   "required": {
     "default": true,
@@ -119,5 +124,6 @@ export const expectedInstanceFullClassDescription = {
     "nullable": false,
     "required": true,
     "type": "boolean",
+    "acknowledge": true,
   },
 };

--- a/types/common/ParameterBag.d.ts
+++ b/types/common/ParameterBag.d.ts
@@ -5,6 +5,7 @@ export namespace sharedOptions {
     let metas: {};
     let filterChange: boolean;
     let immediate: boolean;
+    let acknowledge: boolean;
 }
 export namespace types {
     export namespace boolean {

--- a/types/common/shared-state-types.d.ts
+++ b/types/common/shared-state-types.d.ts
@@ -43,9 +43,14 @@ type SharedStateParameterDescription = {
      */
     event?: boolean;
     /**
+     * - When set to true, the parameter must be
+     * provided at the creation of the shared state.
+     */
+    required?: boolean;
+    /**
      * - When set to `false`, an update will
      * trigger the propagation of a parameter even when its value didn't change.
-     * This option provides a sort of middle ground between the default behavior
+     * This modifier provides a sort of middle ground between the default behavior
      * (e.g. where only changed values are propagated) and the behavior of the `event`
      * option (which has no state per se). Hence, setting this options to `false` if
      * `event=true` makes no sens.
@@ -54,25 +59,31 @@ type SharedStateParameterDescription = {
     /**
      * - When set to `true`, an update will
      * trigger the update listeners immediately on the node that generated the update,
-     * before propagating the change on the network.
-     * This option is useful in cases the network would introduce a noticeable
-     * latency on the client.
+     * before propagating the change on the network. This modifier is useful in cases
+     * the network would introduce a noticeable latency on the client.
      * If for some reason the value is overridden server-side (e.g. in an `updateHook`)
      * the listeners will be called again when the "real" value is received.
+     * Setting this modifier to `true` will trigger the `onUpdate` callback synchronously
+     * according to the `set` call.
      */
     immediate?: boolean;
-    /**
-     * - When set to true, the parameter must be
-     * provided in the initialization values when the state is created.
-     */
-    required?: boolean;
     /**
      * - When set to true, the parameter is never
      * propagated on the network (hence it is no longer a shared parameter :). This
      * is useful to declare some common parameter (e.g. some interface state) that
      * don't need to be shared but to stay in the shared state API paradigm.
+     * Setting this modifier to `true` will trigger the `onUpdate` callback synchronously
+     * according to the `set` call.
      */
     local?: boolean;
+    /**
+     * - When set to false, the acknowledgement
+     * is never sent back to the shared state that initiated an update. This can be
+     * useful to e.g. stream values to the network, but can lead to invalid state.
+     * Setting this modifier to `true` will trigger the `onUpdate` callback synchronously
+     * according to the `set` call.
+     */
+    acknowledge?: boolean;
     /**
      * - Minimum value of the parameter. Only applies
      * for `integer` and `float` types.


### PR DESCRIPTION
When set to `false` remove the acknowledgement roundtrip when a shared state is updated

cf. https://github.com/collective-soundworks/soundworks/issues/112